### PR TITLE
Improve duplicate use of backdrop_get_path()

### DIFF
--- a/ckeditor_blocks.module
+++ b/ckeditor_blocks.module
@@ -169,16 +169,17 @@ function ckeditor_blocks_block_ajax($module, $delta) {
  * @return array
  */
 function ckeditor_blocks_ckeditor_plugins() {
-  $path = backdrop_get_path('module', 'ckeditor_blocks') . '/plugins/blocks';
+  $module_path = backdrop_get_path('module', 'ckeditor_blocks');
+  $plugin_path = $module_path . '/plugins/blocks';
   $plugins['blocks'] = array(
-    'path' => $path,
+    'path' => $plugin_path,
     'file' => 'plugin.js',
-    'css' => array(backdrop_get_path('module', 'ckeditor_blocks') . '/css/ckeditor_blocks.css'),
+    'css' => array($module_path . '/css/ckeditor_blocks.css'),
     'internal' => FALSE,
     'buttons' => array(
       'Blocks' => array(
         'label' => t('Blocks'),
-        'image' => $path . '/icons/blocks.png',
+        'image' => $plugin_path . '/icons/blocks.png',
       ),
     ),
   );


### PR DESCRIPTION
Follow-up from:
https://github.com/backdrop-contrib/ckeditor_blocks/pull/31 and https://github.com/backdrop-contrib/ckeditor_blocks/pull/32

Tested just in case and it works for both the image of the plugin button, and the css of the block rendered in the CKEditor text area.

<img width="1182" alt="Screenshot 2023-02-07 at 12 33 59" src="https://user-images.githubusercontent.com/329818/217236199-cfb51c5a-9537-4ad6-9339-e838ccbf4e95.png">
