### PR TITLE
Remove entity cache disabling

### DIFF
--- a/ckeditor_blocks.module
+++ b/ckeditor_blocks.module
@@ -228,10 +228,3 @@ function _ckeditor_blocks_tips($filter, $format, $long = FALSE) {
     array("@ckeditor_blocks_help" => url("filter/tips/$format->format", array('fragment' => 'filter-ckeditor_blocks'))));
   }
 }
-
-// Disabling entity caching for all nodes.
-// @TODO Still looking for better solution.
-
-function ckeditor_blocks_entity_info_alter(&$info) {
-  $info['node']['entity cache'] = FALSE;
-}


### PR DESCRIPTION
Issue: https://github.com/backdrop-contrib/ckeditor_blocks/issues/26

The filtered text is already not being cached with the use of `'cache' => FALSE` in the hook_filter_info(): https://github.com/backdrop-contrib/ckeditor_blocks/blob/1.x/ckeditor_blocks.module#L198

As it says in the [hook_filter_info() documentation,](https://docs.backdropcms.org/api/backdrop/core%21modules%21filter%21filter.api.php/function/hook_filter_info/1), setting cache to FALSE makes the entire text format not cacheable, which is the proposed solution in #26 